### PR TITLE
Fix Button to accept background-color props.

### DIFF
--- a/src/ui/Button.js
+++ b/src/ui/Button.js
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 import { lighten, darken } from 'polished'
 
 const Button = styled.button.attrs(props => ({ type: 'button' }))`
-  background: ${props => props.backgroundColor || props.theme.secondary};
-  border: 2px solid ${props => props.backgroundColor || props.theme.secondary};
+  background: ${props => props.primary ? props.theme.primary : props.theme.secondary};
+  border: 2px solid ${props => props.primary ? props.theme.primary : props.theme.secondary};
   color: ${props => props.theme.lightText};
   padding: 5px 13px;
   line-height: 32px;
@@ -18,18 +18,18 @@ const Button = styled.button.attrs(props => ({ type: 'button' }))`
 
   &.outline {
     background: none;
-    color: ${props => props.backgroundColor || props.theme.secondary};
+    color: ${props => props.primary ? props.theme.primary : props.theme.secondary};
   }
 
   &:hover {
-    background: ${props => darken(0.2, props.backgroundColor || props.theme.secondary)};
-    border: 2px solid ${props => darken(0.2, props.backgroundColor || props.theme.secondary)};
+    background: ${props => darken(0.2, props.primary ? props.theme.primary : props.theme.secondary)};
+    border: 2px solid ${props => darken(0.2, props.primary ? props.theme.primary : props.theme.secondary)};
     transition: 0.5s ease-out;
   }
 
   &[disabled], &[disabled]:hover {
-    background: ${props => lighten(0.2, props.backgroundColor || props.theme.secondary)};
-    border: 2px solid ${props => lighten(0.2, props.backgroundColor || props.theme.secondary)};
+    background: ${props => lighten(0.2, props.primary ? props.theme.primary : props.theme.secondary)};
+    border: 2px solid ${props => lighten(0.2, props.primary ? props.theme.primary : props.theme.secondary)};
     cursor: not-allowed;
   }
 `

--- a/src/ui/Button.js
+++ b/src/ui/Button.js
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 import { lighten, darken } from 'polished'
 
 const Button = styled.button.attrs(props => ({ type: 'button' }))`
-  background: ${props => props.theme.secondary};
-  border: 2px solid ${props => props.theme.secondary};
+  background: ${props => props.backgroundColor || props.theme.secondary};
+  border: 2px solid ${props => props.backgroundColor || props.theme.secondary};
   color: ${props => props.theme.lightText};
   padding: 5px 13px;
   line-height: 32px;
@@ -18,18 +18,18 @@ const Button = styled.button.attrs(props => ({ type: 'button' }))`
 
   &.outline {
     background: none;
-    color: ${props => props.theme.secondary};
+    color: ${props => props.backgroundColor || props.theme.secondary};
   }
 
   &:hover {
-    background: ${props => darken(0.2, props.theme.secondary)};
-    border: 2px solid ${props => darken(0.2, props.theme.secondary)};
+    background: ${props => darken(0.2, props.backgroundColor || props.theme.secondary)};
+    border: 2px solid ${props => darken(0.2, props.backgroundColor || props.theme.secondary)};
     transition: 0.5s ease-out;
   }
 
   &[disabled], &[disabled]:hover {
-    background: ${props => lighten(0.2, props.theme.secondary)};
-    border: 2px solid ${props => lighten(0.2, props.theme.secondary)};
+    background: ${props => lighten(0.2, props.backgroundColor || props.theme.secondary)};
+    border: 2px solid ${props => lighten(0.2, props.backgroundColor || props.theme.secondary)};
     cursor: not-allowed;
   }
 `

--- a/src/ui/ToasterManager.js
+++ b/src/ui/ToasterManager.js
@@ -5,13 +5,11 @@ import ToasterContext from  './ToasterContext';
 let nextKey = 0;
 function ToasterManager({ children }) {
   const [toasters, setToasters] = useState([]);
-  console.log("rendering with toasters", [...toasters]);
 
   function dismiss(key, toasters) {
     const entry = toasters.find(entry => entry.key === key)
     if(toasters.indexOf(entry) === -1) { return };
 
-    console.log("Dismissing key", key, [...toasters]);
     const newToasters = toasters.filter(entry => entry.key !== key);
     setToasters(newToasters);
   }


### PR DESCRIPTION
We need to accept the button background-color as props, so we can configure the hover/disabled styles according to the customized color. Remove _console.log_ as well.