### PR TITLE
Export global styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vavato-ui",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Vavato UI components and styleguide",
   "author": "vavato-be",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import EllipsisMenu from './ui/EllipsisMenu'
 import EnvContext from './ui/EnvContext'
 import ExportedComponent from './ui/ExportedComponent'
 import FoldablePanel from './ui/FoldablePanel'
+import { GlobalStyle } from './ui/GlobalStyle'
 import { formatDate, formatDateOnly, formatCurrency } from './ui/Formatters'
 import VavatoTheme from './ui/VavatoTheme'
 import Table from './ui/Table'
@@ -40,6 +41,7 @@ export {
   ExportedComponent,
   FormField,
   FoldablePanel,
+  GlobalStyle,
   SearchField,
   StyleGuide,
   Switch,

--- a/src/ui/GlobalStyle.js
+++ b/src/ui/GlobalStyle.js
@@ -21,7 +21,7 @@ export const GlobalStyle = createGlobalStyle`
     font-size: 16px;
     box-sizing: content-box !important;
   }
-  .exported_component *, .exported-comopnent *::before, .exported-component *::after {
+  .exported-component *, .exported-component *::before, .exported-component *::after {
     box-sizing: content-box !important;
   }
 


### PR DESCRIPTION
Export global styles and allow them to be used without an `.exported-component` class.