### PR TITLE
Set git user in NPM package publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn
+      - run: |
+          git config user.name "github-actions"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - run: yarn version --patch
       - run: yarn publish
         env:


### PR DESCRIPTION
This is required to run git commands as part of a workflow. Set GitHub
Actions user email as found in:

https://github.com/actions/checkout/issues/13#issuecomment-724415212