### PR TITLE
VP-1120 Dropdown className should be a variable

### DIFF
--- a/src/ui/Dropdown.js
+++ b/src/ui/Dropdown.js
@@ -54,7 +54,7 @@ function Dropdown({ children, open, className }) {
     ))
   }
   return (
-    <Menu className='className' open={open}>
+    <Menu className={className} open={open}>
       <ul className='unstyled'>{renderChildren()}</ul>
     </Menu>
   )


### PR DESCRIPTION
In the Dropdown component the `className` for the `Menu` was given a string "className" instead of a passed in prop. This meant that the `className` prop was never applied.