### PR TITLE
Only apply List CSS to direct children

### DIFF
--- a/src/ui/List.js
+++ b/src/ui/List.js
@@ -4,7 +4,7 @@ import { rgba } from 'polished'
 const List = styled.ul`
   padding-left: 0px;
 
-  & li {
+  > li {
     display: flex;
     border-top: 0.5px solid ${(props) => rgba(props.theme.secondary, 0.3)};
     font-size: 11px;


### PR DESCRIPTION
We need this in the case where there is a list and each item would have an EllipsisMenu (the List CSS should be applied to the direct items and EllipsisMenu items should have their own CSS).