### PR TITLE
Add options to render FormField inline, on a dark background

### DIFF
--- a/src/ui/Autocomplete.js
+++ b/src/ui/Autocomplete.js
@@ -13,6 +13,11 @@ const Selected = styled('div')`
   font-size: 13px;
   border-radius: 3px;
   color: ${(props) => rgba(props.theme.text, 0.4)};
+
+  &.highlighted {
+    color: ${(props) => props.theme.lightText};
+    border-color: ${(props) => props.theme.lightText};
+  }
 `
 
 const StyledLink = styled('a')`
@@ -58,7 +63,14 @@ function DefaultResultRenderer(result) {
   return <span>{getText()}</span>
 }
 
-function Autocomplete({ onSelect, url, value, resultRenderer, placeholder }) {
+function Autocomplete({
+  onSelect,
+  url,
+  value,
+  resultRenderer,
+  placeholder,
+  highlighted
+}) {
   const [query, setQuery] = useState('')
   const [timer, setTimer] = useState(null)
   const [search, setSearch] = useState()
@@ -113,7 +125,10 @@ function Autocomplete({ onSelect, url, value, resultRenderer, placeholder }) {
   function renderSelected() {
     const renderer = resultRenderer || DefaultResultRenderer
     return (
-      <Selected onClick={() => startQuerying()}>
+      <Selected
+        className={highlighted ? 'highlighted' : ''}
+        onClick={() => startQuerying()}
+      >
         {value ? renderer(value) : placeholder || 'Click to search'}
       </Selected>
     )

--- a/src/ui/FormField.js
+++ b/src/ui/FormField.js
@@ -9,6 +9,10 @@ const Container = styled.div`
   justify-content: flex-start;
   align-items: flex-start;
   margin: 16px 32px 24px 32px;
+
+  &.inline {
+    margin: 0;
+  }
 `
 
 const InputsContainer = styled.div`
@@ -57,18 +61,12 @@ const Label = styled.label`
   margin-bottom: 10px;
 `
 
-function FormField({ name, label, children }) {
-  return React.createElement(
-    Container,
-    null,
-    React.createElement(
-      Label,
-      {
-        htmlFor: name
-      },
-      label
-    ),
-    React.createElement(InputsContainer, null, children)
+function FormField({ name, label, children, inline }) {
+  return (
+    <Container className={inline ? 'inline' : ''}>
+      <Label htmlFor={name}>{label}</Label>
+      <InputsContainer>{children}</InputsContainer>
+    </Container>
   )
 }
 


### PR DESCRIPTION
In order to be able to show a FormField without margin, it can be
defined as inline. Also, for autocomplete input, when rendered over
a dark background, this commit provides the ability to mark it as
highlighted so it uses the general them lightText, without any reduced
transparency.