### PR TITLE
Make active class name for table row override background color

### DIFF
--- a/src/ui/Table.js
+++ b/src/ui/Table.js
@@ -35,7 +35,7 @@ const Table = styled.table`
   }
 
   & tbody tr.active {
-    background: ${(props) => rgba(props.theme.secondary, 0.1)};
+    background: ${(props) => rgba(props.theme.secondary, 0.1)} !important;
   }
 
   & tbody td,


### PR DESCRIPTION
An active row must always show the color defined for the background.
Without the `!important` declaration, the rule `tr:nth-child(odd)` will
override the result, resulting in odd rows not being shown as active.