### PR TITLE
VP-MISC Allow the possibility of having a FormField without label

### DIFF
--- a/src/ui/FormField.js
+++ b/src/ui/FormField.js
@@ -64,7 +64,7 @@ const Label = styled.label`
 function FormField({ name, label, children, inline }) {
   return (
     <Container className={inline ? 'inline' : ''}>
-      <Label htmlFor={name}>{label}</Label>
+      {label ? <Label htmlFor={name}>{label}</Label> : ''}
       <InputsContainer>{children}</InputsContainer>
     </Container>
   )


### PR DESCRIPTION
With this commit, when no label is provided, the Label tag won't even
rendered, instead of being rendered without any value, causing the
element to be lower in the UI than expected.