### PR TITLE
Add ButtonGroup component

### DIFF
--- a/src/ui/ButtonGroup.js
+++ b/src/ui/ButtonGroup.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import styled from 'styled-components'
+import Button from './Button'
+
+const Container = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  margin-bottom: 10px;
+`
+
+const Group = styled.div`
+  padding: 0px 10px;
+  background-color: ${(props) => props.theme.background};
+  border-radius: 3px;
+`
+
+const StyledButton = styled(Button)`
+  background-color: ${(props) => props.theme.background};
+  color: ${(props) => props.theme.text};
+  margin-left: 0px;
+  margin-right: 0px;
+
+  &.active {
+    background-color: ${(props) => props.theme.secondary};
+    color: ${(props) => props.theme.lightText};
+  }
+`
+
+function ButtonGroup({ values, onClick, selectedStyle }) {
+  return (
+    <Container>
+      <Group>
+        {values.map((elem) => (
+          <StyledButton
+            key={elem.value}
+            onClick={() => onClick(elem.value)}
+            style={elem.selected ? selectedStyle : {}}
+          >
+            {elem.text}
+          </StyledButton>
+        ))}
+      </Group>
+    </Container>
+  )
+}
+
+export default ButtonGroup


### PR DESCRIPTION
ButtonGroup component can be used as tabs, so they have no margin nor
border and have a slight modification in the background color, along
with the margins around the buttons.