### PR TITLE
Manually upgrade already published version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vavato-ui",
-  "version": "1.4.41",
+  "version": "1.4.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vavato-ui",
-      "version": "1.4.41",
+      "version": "1.4.42",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vavato-ui",
-  "version": "1.4.41",
+  "version": "1.4.42",
   "description": "Vavato UI components and styleguide",
   "author": "vavato-be",
   "license": "MIT",


### PR DESCRIPTION
Github actions were slow for a while, and two MRs were merged without
triggering the actions. This resulted in the library being published but
the update on the library version could not be committed.