### PR TITLE
VP-1323 Allow SearchField to shrink

### DIFF
--- a/src/ui/SearchField.js
+++ b/src/ui/SearchField.js
@@ -8,14 +8,13 @@ import { safeProps } from './utils'
 
 const Container = styled.div`
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   position: relative;
-  height: 37px;
   font-size: 14px;
   color: ${(props) => rgba(props.theme.text, 0.4)};
 
   & > svg {
-    height: 37px;
     margin-right: calc(100% - 28px);
     position: absolute;
   }

--- a/src/ui/SearchField.js
+++ b/src/ui/SearchField.js
@@ -19,6 +19,11 @@ const Container = styled.div`
     margin-right: calc(100% - 28px);
     position: absolute;
   }
+
+  &.shrinked > input {
+    width: 0;
+    padding-right: 3px;
+  }
 `
 const Input = styled.input.attrs(() => {
   'text'
@@ -44,6 +49,7 @@ const Input = styled.input.attrs(() => {
 function SearchField(props) {
   const input = useRef(null)
   const [focused, setFocused] = useState(false)
+  const [shrinked, setShrinked] = useState(props.shrink)
 
   function emitChange() {
     if (!props.onChange) {
@@ -53,14 +59,27 @@ function SearchField(props) {
     props.onChange(input.current.value)
   }
 
+  function onFocus() {
+    setFocused(true)
+    if (props.shrink) setShrinked(false)
+  }
+
+  function onBlur(e) {
+    setFocused(false)
+    if (props.shrink && !e.target.value) setShrinked(true)
+  }
+
   return (
-    <Container focused={focused} className={focused ? 'focused' : ''}>
+    <Container
+      focused={focused}
+      className={`${focused ? 'focused' : ''} ${shrinked ? 'shrinked' : ''}`}
+    >
       <FontAwesomeIcon icon={faSearch} onClick={() => input.current.focus()} />
       <Input
         ref={input}
         {...safeProps(props)}
-        onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
+        onFocus={onFocus}
+        onBlur={onBlur}
         onChange={(e) => emitChange()}
       />
     </Container>


### PR DESCRIPTION
With `shrink` prop, SearchField only renders the magnifying glass by default. Then on focus, it will show the input field. On blur, it will shrink again, unless there is a value for the input.

![ZjX6dcTimL](https://user-images.githubusercontent.com/9248448/136203213-2f4828e3-d924-40a1-8aa4-88080641eebb.gif)

(second commit: using the flex properties makes it easier to modify the style of the SearchField in the host app in case it's needed)